### PR TITLE
Update to support Rails 6

### DIFF
--- a/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/mysql2_adapter.rb
@@ -11,7 +11,7 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
               alias_method :translate_exception, :translate_exception_with_transaction_isolation_conflict
             end
           end
-          
+
           def supports_isolation_levels?
             true
           end
@@ -29,22 +29,22 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
               'REPEATABLE READ' => :repeatable_read,
               'SERIALIZABLE' => :serializable
           }
-          
+
           def current_isolation_level
             ANSI_ISOLATION_LEVEL[current_vendor_isolation_level]
           end
-          
+
           def current_vendor_isolation_level
             select_value( "SELECT @@session.tx_isolation" ).gsub( '-', ' ' )
           end
-          
+
           def isolation_level( level )
             validate_isolation_level( level )
-            
+
             original_vendor_isolation_level = current_vendor_isolation_level if block_given?
-            
+
             execute( "SET SESSION TRANSACTION ISOLATION LEVEL #{VENDOR_ISOLATION_LEVEL[level]}" )
-            
+
             begin
               yield
             ensure
@@ -52,14 +52,14 @@ if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
             end if block_given?
           end
 
-          def translate_exception_with_transaction_isolation_conflict( exception, message )
+          def translate_exception_with_transaction_isolation_conflict( exception, **args )
             if isolation_conflict?( exception )
               ::ActiveRecord::TransactionIsolationConflict.new( "Transaction isolation conflict detected: #{exception.message}" )
             else
-              translate_exception_without_transaction_isolation_conflict( exception, message )
+              translate_exception_without_transaction_isolation_conflict( exception, **args )
             end
           end
-          
+
           def isolation_conflict?( exception )
             [ "Deadlock found when trying to get lock",
               "Lock wait timeout exceeded"].any? do |error_message|

--- a/lib/transaction_isolation/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/postgresql_adapter.rb
@@ -11,11 +11,11 @@ if defined?( ActiveRecord::ConnectionAdapters::PostgreSQLAdapter )
               alias_method :translate_exception, :translate_exception_with_transaction_isolation_conflict
             end
           end
-                    
+
           def supports_isolation_levels?
             true
           end
-          
+
           VENDOR_ISOLATION_LEVEL = {
               :read_uncommitted => 'READ UNCOMMITTED',
               :read_committed => 'READ COMMITTED',
@@ -29,7 +29,7 @@ if defined?( ActiveRecord::ConnectionAdapters::PostgreSQLAdapter )
               'REPEATABLE READ' => :repeatable_read,
               'SERIALIZABLE' => :serializable
           }
-          
+
           def current_isolation_level
             ANSI_ISOLATION_LEVEL[current_vendor_isolation_level]
           end
@@ -42,9 +42,9 @@ if defined?( ActiveRecord::ConnectionAdapters::PostgreSQLAdapter )
             validate_isolation_level( level )
 
             original_vendor_isolation_level = current_vendor_isolation_level if block_given?
-            
+
             execute "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL #{VENDOR_ISOLATION_LEVEL[level]}"
-            
+
             begin
               yield
             ensure
@@ -52,14 +52,14 @@ if defined?( ActiveRecord::ConnectionAdapters::PostgreSQLAdapter )
             end if block_given?
           end
 
-          def translate_exception_with_transaction_isolation_conflict( exception, message )
+          def translate_exception_with_transaction_isolation_conflict( exception, **args )
             if isolation_conflict?( exception )
               ::ActiveRecord::TransactionIsolationConflict.new( "Transaction isolation conflict detected: #{exception.message}" )
             else
-              translate_exception_without_transaction_isolation_conflict( exception, message )
+              translate_exception_without_transaction_isolation_conflict( exception, **args )
             end
           end
-          
+
           def isolation_conflict?( exception )
             [ "deadlock detected",
               "could not serialize access" ].any? do |error_message|

--- a/lib/transaction_isolation/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/lib/transaction_isolation/active_record/connection_adapters/sqlite3_adapter.rb
@@ -22,12 +22,12 @@ if defined?( ActiveRecord::ConnectionAdapters::SQLite3Adapter )
               :repeatable_read => 'read_uncommitted = 0',
               :serializable => 'read_uncommitted = 0'
           }
-          
+
           ANSI_ISOLATION_LEVEL = {
               'read_uncommitted = 1' => :read_uncommitted,
               'read_uncommitted = 0' => :serializable
           }
-          
+
           def current_isolation_level
             ANSI_ISOLATION_LEVEL[current_vendor_isolation_level]
           end
@@ -35,12 +35,12 @@ if defined?( ActiveRecord::ConnectionAdapters::SQLite3Adapter )
           def current_vendor_isolation_level
             "read_uncommitted = #{select_value( "PRAGMA read_uncommitted" )}"
           end
-          
+
           def isolation_level( level )
             validate_isolation_level( level )
 
             original_vendor_isolation_level = current_vendor_isolation_level if block_given?
-            
+
             execute "PRAGMA #{VENDOR_ISOLATION_LEVEL[level]}"
 
             begin
@@ -49,15 +49,15 @@ if defined?( ActiveRecord::ConnectionAdapters::SQLite3Adapter )
               execute "PRAGMA #{original_vendor_isolation_level}"
             end if block_given?
           end
-          
-          def translate_exception_with_transaction_isolation_conflict( exception, message )
+
+          def translate_exception_with_transaction_isolation_conflict( exception, **args )
             if isolation_conflict?( exception )
               ::ActiveRecord::TransactionIsolationConflict.new( "Transaction isolation conflict detected: #{exception.message}" )
             else
-              translate_exception_without_transaction_isolation_conflict( exception, message )
+              translate_exception_without_transaction_isolation_conflict( exception, **args )
             end
           end
-          
+
           # http://www.sqlite.org/c3ref/c_abort.html
           def isolation_conflict?( exception )
             [ "The database file is locked",

--- a/lib/transaction_isolation/version.rb
+++ b/lib/transaction_isolation/version.rb
@@ -1,3 +1,3 @@
 module TransactionIsolation
-  VERSION = "1.0.5"
+  VERSION = "2.0.0"
 end

--- a/test/integration/active_record/connection_adapters/any_adapter/translate_exception_test.rb
+++ b/test/integration/active_record/connection_adapters/any_adapter/translate_exception_test.rb
@@ -19,19 +19,25 @@ class ActiveRecordTest < Minitest::Test
         def test_translates_low_level_exceptions_to_transaction_isolation_level
           if defined?( ActiveRecord::ConnectionAdapters::Mysql2Adapter )
             message = "Deadlock found when trying to get lock"
-            translated_exception = ActiveRecord::Base.connection.send( :translate_exception, Mysql2::Error.new( message ), message )
+            translated_exception = ActiveRecord::Base.connection.send(
+              :translate_exception, Mysql2::Error.new( message ), message: message
+            )
             assert_equal( ActiveRecord::TransactionIsolationConflict, translated_exception.class )
           end
-          
+
           if defined?( ActiveRecord::ConnectionAdapters::PostgreSQLAdapter )
             message = "deadlock detected"
-            translated_exception = ActiveRecord::Base.connection.send( :translate_exception, PGError.new( message ), message )
+            translated_exception = ActiveRecord::Base.connection.send(
+              :translate_exception, PGError.new( message ), message: message
+            )
             assert_equal( ActiveRecord::TransactionIsolationConflict, translated_exception.class )
           end
-          
+
           if defined?( ActiveRecord::ConnectionAdapters::SQLite3Adapter )
             message = "The database file is locked"
-            translated_exception = ActiveRecord::Base.connection.send( :translate_exception, StandardError.new( message ), message )
+            translated_exception = ActiveRecord::Base.connection.send(
+              :translate_exception, StandardError.new( message ), message: message
+            )
             assert_equal( ActiveRecord::TransactionIsolationConflict, translated_exception.class )
           end
 

--- a/transaction_isolation.gemspec
+++ b/transaction_isolation.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q{Set transaction isolation level in the ActiveRecord in a database agnostic way.
 Works with MySQL, PostgreSQL and SQLite as long as you are using new adapters mysql2, pg or sqlite3.
 Supports all ANSI SQL isolation levels: :serializable, :repeatable_read, :read_committed, :read_uncommitted.}
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 3'
 
   s.files         = `git ls-files -z`.split("\x0").reject { |f| f == 'd' || f.start_with?('test') }
   s.require_paths = ["lib"]

--- a/transaction_isolation.gemspec
+++ b/transaction_isolation.gemspec
@@ -3,21 +3,19 @@ $:.push File.expand_path("../lib", __FILE__)
 require "transaction_isolation/version"
 
 Gem::Specification.new do |s|
-  s.name        = "transaction_isolation"
+  s.name        = "openstax_transaction_isolation"
   s.version     = TransactionIsolation::VERSION
-  s.authors     = ["Piotr 'Qertoip' Włodarek"]
-  s.email       = ["qertoip@gmail.com"]
-  s.homepage    = "https://github.com/qertoip/transaction_isolation"
+  s.authors     = ["Dante Soares", "Piotr 'Qertoip' Włodarek"]
+  s.email       = []
+  s.homepage    = "https://github.com/openstax/transaction_isolation"
   s.summary     = %q{Set transaction isolation level in the ActiveRecord in a database agnostic way.}
   s.description = %q{Set transaction isolation level in the ActiveRecord in a database agnostic way.
 Works with MySQL, PostgreSQL and SQLite as long as you are using new adapters mysql2, pg or sqlite3.
 Supports all ANSI SQL isolation levels: :serializable, :repeatable_read, :read_committed, :read_uncommitted.}
   s.required_ruby_version = '>= 1.9.2'
-  
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f == 'd' || f.start_with?('test') }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "activerecord", ">= 3.0.11"
+  s.add_runtime_dependency "activerecord", ">= 6"
 end


### PR DESCRIPTION
Mainly changed instances of `translate_exception` to use keyword arguments.